### PR TITLE
Fix mock_open incompatibility with requests>=2.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vudials_client"
 dependencies = [
         "requests>=2.32.5"
 ]
-version = "2025.9.3"
+version = "2026.6.0"
 authors = [
   { name="Erin L. Kolp", email="erinlkolpfoss@gmail.com" },
 ]

--- a/tests/test_vudialsclient.py
+++ b/tests/test_vudialsclient.py
@@ -4,7 +4,7 @@ import re
 import pytest
 import responses as resp
 from requests.exceptions import HTTPError
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 
 from vudials_client.vudialsclient import VUUtil, VUAdminUtil, VUDial, VUAdmin
 
@@ -383,28 +383,28 @@ class TestVUDialSetDialBackground:
     @resp.activate
     def test_success(self, vudial):
         resp.add(resp.POST, f"{BASE}/api/v0/dial/uid1/image/set", json={}, status=200)
-        with patch("builtins.open", mock_open(read_data=b"fake image")):
+        with patch("builtins.open", return_value=io.BytesIO(b"fake image")):
             r = vudial.set_dial_background("uid1", "image.png")
         assert r.status_code == 200
 
     @resp.activate
     def test_uses_post(self, vudial):
         resp.add(resp.POST, f"{BASE}/api/v0/dial/uid1/image/set", json={}, status=200)
-        with patch("builtins.open", mock_open(read_data=b"fake image")):
+        with patch("builtins.open", return_value=io.BytesIO(b"fake image")):
             vudial.set_dial_background("uid1", "image.png")
         assert resp.calls[0].request.method == "POST"
 
     @resp.activate
     def test_correct_endpoint(self, vudial):
         resp.add(resp.POST, f"{BASE}/api/v0/dial/uid1/image/set", json={}, status=200)
-        with patch("builtins.open", mock_open(read_data=b"fake image")):
+        with patch("builtins.open", return_value=io.BytesIO(b"fake image")):
             vudial.set_dial_background("uid1", "image.png")
         assert "/dial/uid1/image/set" in resp.calls[0].request.url
 
     @resp.activate
     def test_http_error_propagates(self, vudial):
         resp.add(resp.POST, f"{BASE}/api/v0/dial/uid1/image/set", status=500)
-        with patch("builtins.open", mock_open(read_data=b"fake image")):
+        with patch("builtins.open", return_value=io.BytesIO(b"fake image")):
             with pytest.raises(HTTPError):
                 vudial.set_dial_background("uid1", "image.png")
 


### PR DESCRIPTION
## Summary
- `requests` 2.33.0 (released 2026-03-25) changed multipart file encoding in `_encode_files()` to use a `typing.Protocol` `isinstance` check (`SupportsRead`) instead of `hasattr(fp, "read")`. Under Python 3.12+, `MagicMock` objects produced by `unittest.mock.mock_open()` fail that `isinstance` check even though `hasattr` is `True`, so `fp.read()` never gets called and the raw mock reaches `urllib3`'s multipart encoder, crashing with `TypeError: a bytes-like object is required, not 'MagicMock'`.
- This broke all 4 tests in `TestVUDialSetDialBackground` against any `requests>=2.33` install. Since `pyproject.toml` pins only `requests>=2.32.5` with no upper bound, the next fresh install (including CI) would fail.
- Fixed by replacing `mock_open(...)` with `io.BytesIO(...)`-backed fakes for the patched `open()`, matching the pattern already used in `TestVUUtilSendHttpRequest.test_post_when_files_provided`. No production code (`vudialsclient.py`) needed changes — it works correctly with real file objects.
- Bumped version to `2026.6.0`.

## Test plan
- [x] `pytest tests/ -v --cov=vudials_client --cov-report=term-missing` — 104 passed, 100% coverage, run against `requests==2.34.2` (current latest)
- [x] Verified the failure reproduces on `main` with a fresh `requests` install before this fix