### PR TITLE
Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,7 +36,7 @@ jobs:
           pytest tests/ -v --cov=vudials_client --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: matrix.python-version == '3.12'
         with:
           name: coverage-report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -26,7 +26,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary
- GitHub is forcing Actions to run on Node 24 by default starting June 2026, with Node 20 removed from runners in September 2026 — this was already surfacing as deprecation warnings on workflow runs.
- Bump `actions/checkout` v4→v5, `actions/setup-python` v5→v6, `actions/upload-artifact` v4→v6, and `actions/download-artifact` v4→v7 in `ci.yml` and `publish.yml`, since these are the majors that default to the `node24` runtime.

## Test plan
- [x] CI workflow runs on this `claude/**` branch (triggers automatically per `ci.yml`) — verify the matrix passes on Python 3.11–3.14 with no deprecation warnings.
- [ ] `publish.yml` only runs on a GitHub release, so it can't be exercised by CI here — verify on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)