### PR TITLE
Fix URL encoding, silent GET fallthrough, and update_api_key HTTP method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vudials_client"
 dependencies = [
         "requests>=2.32.5"
 ]
-version = "2026.6.0"
+version = "2026.6.1"
 authors = [
   { name="Erin L. Kolp", email="erinlkolpfoss@gmail.com" },
 ]

--- a/src/vudials_client/vudialsclient.py
+++ b/src/vudials_client/vudialsclient.py
@@ -13,7 +13,7 @@ class VUUtil:
         # This means it will appear in server access logs, proxy logs, and
         # HTTP client history. If the server adds header-based authentication
         # in the future, prefer an Authorization or X-API-Key header instead.
-        return f'{server_url}/api/v0/{api_call}?key={quote(api_key)}{keyword_params}'
+        return f'{server_url}/api/v0/{api_call}?key={quote(api_key, safe="")}{keyword_params}'
 
     def send_http_request(self, path_uri: str, files: dict, timeout: int = 10) -> requests.Response:
         if files is not None:
@@ -27,13 +27,15 @@ class VUUtil:
 class VUAdminUtil:
     def get_uri(self, server_url: str, api_key: str, api_call: str, keyword_params: str) -> str:
         # Security note: See VUUtil.get_uri — same key-in-URL caveat applies.
-        return f'{server_url}/api/v0/{api_call}?admin_key={quote(api_key)}{keyword_params}'
+        return f'{server_url}/api/v0/{api_call}?admin_key={quote(api_key, safe="")}{keyword_params}'
 
     def send_http_request(self, path_uri: str, method: str, timeout: int = 10) -> requests.Response:
         if method == "post":
             r = requests.post(path_uri, timeout=timeout)
-        else:
+        elif method == "get":
             r = requests.get(path_uri, timeout=timeout)
+        else:
+            raise ValueError(f"Unsupported HTTP method: {method!r}")
         r.raise_for_status()
         return r
 
@@ -136,7 +138,7 @@ class VUDial(VUUtil):
         :return: requests.Response
         """
         api_call = f'dial/{quote(uid, safe="")}/name'
-        params = f'&name={quote(name)}'
+        params = f'&name={quote(name, safe="")}'
         r_uri = self.get_uri(self.server_url, self.key, api_call, params)
         return self.send_http_request(r_uri, None)
 
@@ -232,7 +234,7 @@ class VUAdmin(VUAdminUtil):
         :param target_key: str, the key to remove.
         :return: requests.Response
         """
-        params = f'&key={quote(target_key)}'
+        params = f'&key={quote(target_key, safe="")}'
         r_uri = self.get_uri(self.server_url, self.key, 'admin/keys/remove', params)
         return self.send_http_request(r_uri, 'get')
 
@@ -244,7 +246,7 @@ class VUAdmin(VUAdminUtil):
         :param dials: str, the dials to associate with the key.
         :return: requests.Response
         """
-        params = f'&name={quote(name)}&dials={quote(dials)}'
+        params = f'&name={quote(name, safe="")}&dials={quote(dials, safe="")}'
         r_uri = self.get_uri(self.server_url, self.key, 'admin/keys/create', params)
         return self.send_http_request(r_uri, 'post')
 
@@ -257,6 +259,6 @@ class VUAdmin(VUAdminUtil):
         :param dials: str, the updated dials to associate.
         :return: requests.Response
         """
-        params = f'&key={quote(target_key)}&name={quote(name)}&dials={quote(dials)}'
+        params = f'&key={quote(target_key, safe="")}&name={quote(name, safe="")}&dials={quote(dials, safe="")}'
         r_uri = self.get_uri(self.server_url, self.key, 'admin/keys/update', params)
-        return self.send_http_request(r_uri, 'get')
+        return self.send_http_request(r_uri, 'post')

--- a/tests/test_vudialsclient.py
+++ b/tests/test_vudialsclient.py
@@ -55,6 +55,11 @@ class TestVUUtilGetUri:
         assert "k%26admin_key%3Devil" in uri
         assert "admin_key=evil" not in uri
 
+    def test_api_key_with_slash_url_encoded(self):
+        uri = self.util.get_uri("http://localhost:5340", "key/with/slash", "dial/list", "")
+        assert "key%2Fwith%2Fslash" in uri
+        assert "key/with/slash" not in uri
+
 
 class TestVUUtilSendHttpRequest:
     def setup_method(self):
@@ -150,6 +155,11 @@ class TestVUAdminUtilGetUri:
         assert "a%26key%3Devil" in uri
         assert "key=evil" not in uri
 
+    def test_admin_key_with_slash_url_encoded(self):
+        uri = self.util.get_uri("http://localhost:5340", "key/with/slash", "admin/keys/list", "")
+        assert "key%2Fwith%2Fslash" in uri
+        assert "key/with/slash" not in uri
+
 
 class TestVUAdminUtilSendHttpRequest:
     def setup_method(self):
@@ -169,11 +179,9 @@ class TestVUAdminUtilSendHttpRequest:
         assert resp.calls[0].request.method == "POST"
         assert r.status_code == 200
 
-    @resp.activate
-    def test_non_post_defaults_to_get(self):
-        resp.add(resp.GET, f"{BASE}/api/v0/test", json={}, status=200)
-        self.util.send_http_request(f"{BASE}/api/v0/test", "put")
-        assert resp.calls[0].request.method == "GET"
+    def test_unknown_method_raises_value_error(self):
+        with pytest.raises(ValueError, match="put"):
+            self.util.send_http_request(f"{BASE}/api/v0/test", "put")
 
     @resp.activate
     def test_raises_on_404(self):
@@ -470,6 +478,14 @@ class TestVUDialSetDialName:
         assert "My%20Dial" in url or "My+Dial" in url
 
     @resp.activate
+    def test_name_slash_url_encoded(self, vudial):
+        resp.add(resp.GET, f"{BASE}/api/v0/dial/uid1/name", json={}, status=200)
+        vudial.set_dial_name("uid1", "My/Dial")
+        url = resp.calls[0].request.url
+        assert "My%2FDial" in url
+        assert "My/Dial" not in url
+
+    @resp.activate
     def test_http_error_propagates(self, vudial):
         resp.add(resp.GET, f"{BASE}/api/v0/dial/uid1/name", status=400)
         with pytest.raises(HTTPError):
@@ -705,6 +721,14 @@ class TestVUAdminRemoveApiKey:
         assert "key+with+spaces" in url or "key%20with%20spaces" in url
 
     @resp.activate
+    def test_target_key_slash_url_encoded(self, vuadmin):
+        resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/remove", json={}, status=200)
+        vuadmin.remove_api_key("key/with/slash")
+        url = resp.calls[0].request.url
+        assert "key%2Fwith%2Fslash" in url
+        assert "key/with/slash" not in url
+
+    @resp.activate
     def test_http_error_propagates(self, vuadmin):
         resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/remove", status=404)
         with pytest.raises(HTTPError):
@@ -744,6 +768,14 @@ class TestVUAdminCreateApiKey:
         assert "dials=" in url
 
     @resp.activate
+    def test_name_slash_url_encoded(self, vuadmin):
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/create", json={}, status=200)
+        vuadmin.create_api_key("my/key", "all")
+        url = resp.calls[0].request.url
+        assert "name=my%2Fkey" in url
+        assert "name=my/key" not in url
+
+    @resp.activate
     def test_http_error_propagates(self, vuadmin):
         resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/create", status=400)
         with pytest.raises(HTTPError):
@@ -758,25 +790,25 @@ class TestVUAdminCreateApiKey:
 class TestVUAdminUpdateApiKey:
     @resp.activate
     def test_success(self, vuadmin):
-        resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
         r = vuadmin.update_api_key("newname", "existing-key", "all")
         assert r.status_code == 200
 
     @resp.activate
     def test_correct_endpoint(self, vuadmin):
-        resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
         vuadmin.update_api_key("newname", "existing-key", "all")
         assert "/api/v0/admin/keys/update" in resp.calls[0].request.url
 
     @resp.activate
-    def test_uses_get(self, vuadmin):
-        resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
+    def test_uses_post(self, vuadmin):
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
         vuadmin.update_api_key("newname", "existing-key", "all")
-        assert resp.calls[0].request.method == "GET"
+        assert resp.calls[0].request.method == "POST"
 
     @resp.activate
     def test_correct_params(self, vuadmin):
-        resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
         vuadmin.update_api_key("newname", "existing-key", "all")
         url = resp.calls[0].request.url
         assert "name=newname" in url
@@ -784,7 +816,15 @@ class TestVUAdminUpdateApiKey:
         assert "dials=all" in url
 
     @resp.activate
+    def test_name_slash_url_encoded(self, vuadmin):
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/update", json={}, status=200)
+        vuadmin.update_api_key("new/name", "existing-key", "all")
+        url = resp.calls[0].request.url
+        assert "name=new%2Fname" in url
+        assert "name=new/name" not in url
+
+    @resp.activate
     def test_http_error_propagates(self, vuadmin):
-        resp.add(resp.GET, f"{BASE}/api/v0/admin/keys/update", status=404)
+        resp.add(resp.POST, f"{BASE}/api/v0/admin/keys/update", status=404)
         with pytest.raises(HTTPError):
             vuadmin.update_api_key("name", "no-such-key", "all")


### PR DESCRIPTION
## Summary

- **URL encoding**: All query parameter values now use `quote(value, safe="")` so characters like `/` are percent-encoded rather than passed raw into the query string. Previously only path segments (`uid`) used `safe=""` — all other values used the default `safe='/'`.
- **Silent GET fallthrough**: `VUAdminUtil.send_http_request` previously fell through to GET for any unrecognized method string (typos, `"put"`, etc.). It now raises `ValueError` for anything other than `"get"` or `"post"`.
- **`update_api_key` HTTP method**: Changed from `"get"` to `"post"` to match the server's `Admin_Keys_Update` handler, which only implements `post()`. The GET calls were being silently ignored by the server.
- **Version bump**: `2026.6.0` → `2026.6.1`

## Test plan

- [ ] All 110 tests pass (`pytest tests/ -v`)
- [ ] New tests added for slash encoding in `get_uri` (both `VUUtil` and `VUAdminUtil`), `set_dial_name`, `remove_api_key`, `create_api_key`, and `update_api_key`
- [ ] `test_non_post_defaults_to_get` replaced with `test_unknown_method_raises_value_error`
- [ ] `TestVUAdminUpdateApiKey` updated to register `POST` stubs and assert `POST` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)