### PR TITLE
Correct RGB backlight range to 0-100 and bump to 2026.7.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ These are pre-existing design constraints of the VU1 server API — do not silen
 
 1. **Plain HTTP only.** The server only listens on HTTP; HTTPS is not supported. Keep traffic on trusted local interfaces.
 2. **Key-in-URL authentication.** Both `key=` and `admin_key=` parameters appear in the query string and will be recorded in server access logs, proxy logs, and HTTP client history. This is intentional until the upstream server adds header-based auth.
-3. **No input validation in the library.** The library does not validate value ranges (e.g., RGB 0–255) or UID format; that is the server's responsibility.
+3. **No input validation in the library.** The library does not validate value ranges (e.g., RGB 0–100) or UID format; that is the server's responsibility.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ print(dial_list.json())
 # Set first dial to 75% with a blue backlight
 uid = dial_list.json()[0]["uid"]
 vu_meter.set_dial_value(uid, 75)
-vu_meter.set_dial_color(uid, 0, 0, 255)
+vu_meter.set_dial_color(uid, 0, 0, 100)
 
 # List API keys
 api_key_list = admin_api.list_api_keys()
@@ -82,7 +82,7 @@ vu_meter = vudialsclient.VUDial(server_address, server_port, api_key)
 | `list_dials()` | List all connected dials |
 | `get_dial_info(uid)` | Get status/info for a specific dial |
 | `set_dial_value(uid, value)` | Set the dial position (0–100) |
-| `set_dial_color(uid, red, green, blue)` | Set the backlight color (0–255 each channel) |
+| `set_dial_color(uid, red, green, blue)` | Set the backlight color (0–100 each channel) |
 | `set_dial_background(uid, file)` | Upload a background image file |
 | `get_dial_image_crc(uid)` | Get the CRC of the current background image |
 | `set_dial_name(uid, name)` | Assign a name to a dial |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vudials_client"
 dependencies = [
         "requests>=2.32.5"
 ]
-version = "2026.7.0"
+version = "2026.7.1"
 authors = [
   { name="Erin L. Kolp", email="erinlkolpfoss@gmail.com" },
 ]

--- a/src/vudials_client/vudialsclient.py
+++ b/src/vudials_client/vudialsclient.py
@@ -95,9 +95,9 @@ class VUDial(VUUtil):
         Set the dial backlight color.
 
         :param uid: str, the uid of the vu-dial.
-        :param red: int, red channel (0-255).
-        :param green: int, green channel (0-255).
-        :param blue: int, blue channel (0-255).
+        :param red: int, red channel (0-100).
+        :param green: int, green channel (0-100).
+        :param blue: int, blue channel (0-100).
         :return: requests.Response
         """
         api_call = f'dial/{quote(uid, safe="")}/backlight'


### PR DESCRIPTION
## Summary

The VU1 server clamps each backlight channel to `max(0, min(x, 100))` (`server_dial_handler.py`), so the valid RGB range is **0–100**, not 0–255 as the module and README previously documented. Values above 100 don't error — they silently saturate. This corrects the documented range everywhere.

## Changes

- **`src/vudials_client/vudialsclient.py`** — `set_dial_color` docstrings: `(0-255)` → `(0-100)` for red/green/blue.
- **`README.md`** — example uses `set_dial_color(uid, 0, 0, 100)`; API table now says `(0–100 each channel)`.
- **`CLAUDE.md`** — "RGB 0–255" example → "RGB 0–100" for consistency.
- **`pyproject.toml`** — version bumped `2026.7.0` → `2026.7.1`.

## Notes

- Tests are unchanged and all **120 pass**. They pass `255` only as arbitrary distinct values to verify URL construction/encoding; the library does no range validation by design ("no input validation in the library" convention), so no clamping was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)